### PR TITLE
Yl 4121 add user matching to prebid

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -200,7 +200,7 @@ export const spec = {
       }
       syncs.push({
         type: 'iframe',
-        url: `https://ad.yieldlab.net/d/6846326/766/2x2?${params.join('&')}`
+        url: `${ENDPOINT}/d/6846326/766/2x2?${params.join('&')}`
       });
     }
 

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -1,4 +1,4 @@
-import { _each, isPlainObject, isArray, deepAccess } from '../src/utils.js';
+import {_each, isPlainObject, isArray, deepAccess, timestamp} from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js'
 import find from 'core-js-pure/features/array/find.js'
 import { VIDEO, BANNER, NATIVE } from '../src/mediaTypes.js'
@@ -174,6 +174,37 @@ export const spec = {
       }
     })
     return bidResponses
+  },
+
+  /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @param {Object} gdprConsent Is the GDPR Consent object wrapping gdprApplies {boolean} and consentString {string} attributes.
+   * @param {string} uspConsent Is the US Privacy Consent string.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
+  getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent) {
+    const syncs = [];
+
+    if (syncOptions.iframeEnabled) {
+      let params = [];
+      params.push(`ts=${timestamp()}`);
+      params.push(`type=h`)
+      if (gdprConsent && (typeof gdprConsent.gdprApplies === 'boolean')) {
+        params.push(`gdpr=${gdprConsent.gdprApplies ? '1' : '0'}`);
+      }
+      if (gdprConsent && (typeof gdprConsent.consentString === 'string')) {
+        params.push(`consent=${gdprConsent.consentString}`);
+      }
+      syncs.push({
+        type: 'iframe',
+        url: `https://ad.yieldlab.net/d/6846326/766/2x2?${params.join('&')}`
+      });
+    }
+
+    return syncs;
   }
 };
 

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -193,10 +193,10 @@ export const spec = {
       params.push(`ts=${timestamp()}`);
       params.push(`type=h`)
       if (gdprConsent && (typeof gdprConsent.gdprApplies === 'boolean')) {
-        params.push(`gdpr=${gdprConsent.gdprApplies ? '1' : '0'}`);
+        params.push(`gdpr=${Number(gdprConsent.gdprApplies)}`);
       }
       if (gdprConsent && (typeof gdprConsent.consentString === 'string')) {
-        params.push(`consent=${gdprConsent.consentString}`);
+        params.push(`gdpr_consent=${gdprConsent.consentString}`);
       }
       syncs.push({
         type: 'iframe',

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -414,4 +414,40 @@ describe('yieldlabBidAdapter', function () {
       expect(result[0].vastUrl).to.include('&iab_content=id%3Afoo_id%2Cepisode%3A99%2Ctitle%3Afoo_title%252Cbar_title%2Cseries%3Afoo_series%2Cseason%3As1%2Cartist%3Afoo%2520bar%2Cgenre%3Abaz%2Cisrc%3ACC-XXX-YY-NNNNN%2Curl%3Ahttp%253A%252F%252Ffoo_url.de%2Ccat%3Acat1%7Ccat2%252Cppp%7Ccat3%257C%257C%257C%252F%252F%2Ccontext%3A7%2Ckeywords%3Ak1%252C%7Ck2..%2Clive%3A0')
     })
   })
+
+  describe('getUserSyncs', function () {
+    const syncOptions = {
+      iframeEnabled: true,
+      pixelEnabled: false
+    };
+    const expectedUrlSnippets = ['https://ad.yieldlab.net/d/6846326/766/2x2?', 'ts=', 'type=h'];
+
+    it('should return user sync as expected', function () {
+      const bidRequest = {
+        gdprConsent: {
+          consentString: 'BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA',
+          gdprApplies: true
+        },
+        uspConsent: '1YYY'
+      };
+      const sync = spec.getUserSyncs(syncOptions, [], bidRequest.gdprConsent, bidRequest.uspConsent);
+      expect(expectedUrlSnippets.every(urlSnippet => sync[0].url.includes(urlSnippet)));
+      expect(sync[0].url).to.have.string('gdpr=' + Number(bidRequest.gdprConsent.gdprApplies));
+      expect(sync[0].url).to.have.string('consent=' + bidRequest.gdprConsent.consentString);
+      // USP consent should be ignored
+      expect(sync[0].url).not.have.string('usp_consent=');
+      expect(sync[0].type).to.have.string('iframe');
+    });
+
+    it('should return user sync even without gdprApplies in gdprConsent', function () {
+      const gdprConsent = {
+        consentString: 'BN5lERiOMYEdiAKAWXEND1AAAAE6DABACMA'
+      }
+      const sync = spec.getUserSyncs(syncOptions, [], gdprConsent, undefined);
+      expect(expectedUrlSnippets.every(urlSnippet => sync[0].url.includes(urlSnippet)));
+      expect(sync[0].url).to.have.string('consent=' + gdprConsent.consentString);
+      expect(sync[0].url).not.have.string('gdpr=');
+      expect(sync[0].type).to.have.string('iframe');
+    });
+  });
 })

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -433,7 +433,7 @@ describe('yieldlabBidAdapter', function () {
       const sync = spec.getUserSyncs(syncOptions, [], bidRequest.gdprConsent, bidRequest.uspConsent);
       expect(expectedUrlSnippets.every(urlSnippet => sync[0].url.includes(urlSnippet)));
       expect(sync[0].url).to.have.string('gdpr=' + Number(bidRequest.gdprConsent.gdprApplies));
-      expect(sync[0].url).to.have.string('consent=' + bidRequest.gdprConsent.consentString);
+      expect(sync[0].url).to.have.string('gdpr_consent=' + bidRequest.gdprConsent.consentString);
       // USP consent should be ignored
       expect(sync[0].url).not.have.string('usp_consent=');
       expect(sync[0].type).to.have.string('iframe');
@@ -445,7 +445,7 @@ describe('yieldlabBidAdapter', function () {
       }
       const sync = spec.getUserSyncs(syncOptions, [], gdprConsent, undefined);
       expect(expectedUrlSnippets.every(urlSnippet => sync[0].url.includes(urlSnippet)));
-      expect(sync[0].url).to.have.string('consent=' + gdprConsent.consentString);
+      expect(sync[0].url).to.have.string('gdpr_consent=' + gdprConsent.consentString);
       expect(sync[0].url).not.have.string('gdpr=');
       expect(sync[0].type).to.have.string('iframe');
     });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

- YL-4121
- Added support for user matching to the YL Prebid.js adapter
- Configured iframe as sync option in Prebid
- Used https://ad.yieldlab.net/d/6846326/766/2x2?ts=[timestamp]&type=h&gdpr=1&consent=[tcfConsentString] as URL for the standard user matching container
- Set our gdpr parameter according to the value of gdprApplies in Prebid.js
- Ignore the uspConsent parameter of the method
